### PR TITLE
update cm

### DIFF
--- a/helm/kube-downscaler/templates/configmap.yaml
+++ b/helm/kube-downscaler/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   {{- include "labels.common" . | nindent 4 }}
   name: {{ template "kube-downscaler.name" . }}
   namespace: {{ .Release.Namespace }}
-data: | 
+data: 
 {{ .Values.scalingInfo | indent 2 }}

--- a/helm/kube-downscaler/values.yaml
+++ b/helm/kube-downscaler/values.yaml
@@ -36,7 +36,7 @@ daemonset:
   list: []
 
 scalingInfo: |
-  DEFAULT_DOWNTIME="Sat-Sat 02:00-24:00 CET,Sun-Sun 00:00-22:00"
+  DEFAULT_DOWNTIME: "Sat-Sat 02:00-24:00 CET,Sun-Sun 00:00-22:00"
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
App is failing to deploy with following message : 
```
Upgrade "kube-downscaler" failed: failed to create resource: ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal string into Go struct field ConfigMap.data of type map[string]string
```

This PR is attempting to fix that