### PR TITLE
push kube-downscaler app to all collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,69 @@ workflows:
   package-and-push-chart-on-tag:
     jobs:
       - architect/push-to-app-catalog:
-          context: "architect"
-          executor: "app-build-suite"
-          name: "package and push kube-downscaler chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
-          chart: "kube-downscaler"
+          context: architect
+          executor: app-build-suite
+          name: "package and push kube-downscaler chart to control-plane-catalogs"
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
+          chart: kube-downscaler
           # Trigger job on git tag.
           filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: capa-app-collection
+          app_name: "kube-downscaler"
+          app_namespace: "kube-system"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - "package and push kube-downscaler chart to control-plane-catalogs"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: capz-app-collection
+          app_name: "kube-downscaler"
+          app_namespace: "kube-system"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - "package and push kube-downscaler chart to control-plane-catalogs"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: vsphere-app-collection
+          app_name: "kube-downscaler"
+          app_namespace: "kube-system"
+          app_collection_repo: "vsphere-app-collection"
+          requires:
+            - "package and push kube-downscaler chart to control-plane-catalogs"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: cloud-director-app-collection
+          app_name: "kube-downscaler"
+          app_namespace: "kube-system"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - "package and push kube-downscaler chart to control-plane-catalogs"
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Push `kube-downscaler` app to all collections.
+
 ## [0.2.0] - 2024-07-15
 
 ### Changed


### PR DESCRIPTION
With the latest changes which lead to the app being disabled by default, we can push it to all collections safely and only enable it selectively on specific installations.
