### PR TITLE
add cilium network policy template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cilium network policy template.
+
 ## [0.3.0] - 2024-07-17
 
 ### Changed

--- a/helm/kube-downscaler/templates/cilium-networkpolicy.yaml
+++ b/helm/kube-downscaler/templates/cilium-networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ciliumNetworkPolicy.enabled -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "kube-downscaler.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "labels.common" . | nindent 4 }}
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+    - world
+  - toEndpoints:
+    - matchLabels:
+        k8s-app: coredns
+    - matchLabels:
+        k8s-app: k8s-dns-node-cache
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: ANY
+      - port: "1053"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+  - toEndpoints:
+    - matchLabels:
+        app.kubernetes.io/name: ingress-nginx
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: ANY
+      - port: "443"
+        protocol: ANY
+  endpointSelector:
+    matchLabels:
+    {{- include "labels.selector" . | nindent 6 }}
+{{- end }}

--- a/helm/kube-downscaler/values.yaml
+++ b/helm/kube-downscaler/values.yaml
@@ -17,6 +17,9 @@ resources: {}
 # Reconciliation interval
 interval: 60
 
+ciliumNetworkPolicy:
+  enabled: false
+
 debug:
   enabled: true
 


### PR DESCRIPTION
`kube-downscaler` is having timeouts on `glean` and `glasgow` when trying to list pods. After manually deploying the ciliumnetpol which template is written in this PR, those error logs disappeared.